### PR TITLE
Add unit tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,3 +41,9 @@ displaydoc = { version = "0.2", default-features = false }
 lazy_static = "1.4"
 url = "2.3"
 walkdir = "2.3"
+
+[dev-dependencies]
+mockall = "0.11.3"
+mockall_double = "0.2.1"
+rustversion = "1.0"
+temp-env = "0.3.2"


### PR DESCRIPTION
- Added unit tests for cargo_build.rs and env.rs
- Below crates were used for unit testing 
      1.   [mockall](https://crates.io/crates/mockall) 
      2.   [temp-env](https://crates.io/crates/temp-env) 
      3.   [rustversion](https://crates.io/crates/rustversion) 

